### PR TITLE
ci: add ci workflow for automated build and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -191,6 +191,7 @@ pub fn get_file_type(package_type: PackageType) -> &'static str {
             PackageType::SidechainCli => "zip",
             PackageType::CardanoNode => "tar.gz",
             PackageType::CardanoCli => "tar.gz",
+            PackageType::Jujutsu => "tar.gz",
             PackageType::Mithril => "tar.gz",
             PackageType::Scrolls => "tar.gz",
             PackageType::Zellij => "tar.gz",


### PR DESCRIPTION
- add a github actions workflow for ci to build and test on ubuntu and macos
- configure workflow to run for pushes and pull requests on the main branch