### PR TITLE
build: specify rust nightly toolchain and required components

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly"
+components = ["cargo", "clippy", "rust-analyzer", "rustc", "rustfmt"]
+profile = "minimal"


### PR DESCRIPTION
add rust-toolchain file to specify nightly toolchain and minimal set of components