### PR TITLE
cli: rename binary to hj

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ comfy-table = "7.1.1"
 
 [[bin]]
 path = "src/main.rs"
-name = "hyper-jump"
+name = "hj"
 proc-macro = false
 required-features = []
 

--- a/readme.md
+++ b/readme.md
@@ -38,44 +38,44 @@ cargo install hyper-jump
 make sure the install directory is on your `PATH`.
 
 ```bash
-export PATH="$(hyper-jump prefix):$PATH"
+export PATH="$(hj prefix):$PATH"
 ```
 
 on macos, you can also set the user path once:
 
 ```bash
-sudo launchctl config user path "$(hyper-jump prefix):${PATH}"
+sudo launchctl config user path "$(hj prefix):${PATH}"
 ```
 
 ## usage
 
-run `hyper-jump --help` if you can't remember the subcommands.
+run `hj --help` if you can't remember the subcommands.
 
 quick start
 
 ```sh
-hyper-jump list-remote reth
-hyper-jump install reth v1.10.2
-hyper-jump use reth v1.10.2
-hyper-jump list reth
+hj list-remote reth
+hj install reth v1.10.2
+hj use reth v1.10.2
+hj list reth
 ```
 
 commands
 
-- `hyper-jump install <package> <version|latest>` install a version
-- `hyper-jump use <package> <version|latest>` switch to a version and mark it as used
-- `hyper-jump list <package>` show installed versions
-- `hyper-jump list-remote <package>` show remote versions
-- `hyper-jump uninstall <package> <version>` remove a version
-- `hyper-jump erase` remove all installed versions
-- `hyper-jump prefix` print the bin dir used for shims
+- `hj install <package> <version|latest>` install a version
+- `hj use <package> <version|latest>` switch to a version and mark it as used
+- `hj list <package>` show installed versions
+- `hj list-remote <package>` show remote versions
+- `hj uninstall <package> <version>` remove a version
+- `hj erase` remove all installed versions
+- `hj prefix` print the bin dir used for shims
 
 notes
 
 - `version` accepts tags like `v1.10.2` or `latest`
 - `--output-format json|table` or `HYPER_JUMP_OUTPUT_FORMAT` changes list output format
 - `--root-dir <path>` or `HYPER_JUMP_ROOT_DIR` overrides the data dir
-- make sure the path from `hyper-jump prefix` is on your `PATH` or nothing will run
+- make sure the path from `hj prefix` is on your `PATH` or nothing will run
 
 ## supported packages
 

--- a/src/adapters/proxy.rs
+++ b/src/adapters/proxy.rs
@@ -86,7 +86,8 @@ fn add_to_path(env: &impl Env, installation_dir: &Path) -> Result<()> {
 }
 
 async fn read_proxy_version(process: &impl Process, alias: &str) -> Result<Option<String>> {
-    let output = match process.output(Path::new(alias), &["--&hyper-jump".to_string()]).await {
+    let version_arg = format!("--{}", env!("CARGO_BIN_NAME"));
+    let output = match process.output(Path::new(alias), &[version_arg]).await {
         Ok(output) => output,
         Err(_) => return Ok(None),
     };

--- a/src/app/proxy.rs
+++ b/src/app/proxy.rs
@@ -19,9 +19,13 @@ pub async fn handle_proxy(
     platform: &impl Platform,
     process: &impl Process,
 ) -> miette::Result<()> {
-    if !rest_args.is_empty() && rest_args[0].eq("--hyper-jump") {
+    if !rest_args.is_empty() && rest_args[0].eq(concat!("--", env!("CARGO_BIN_NAME"))) {
         output
-            .write_line(&format!("hyper-jump v{}", env!("CARGO_PKG_VERSION")))
+            .write_line(&format!(
+                "{} v{}",
+                env!("CARGO_BIN_NAME"),
+                env!("CARGO_PKG_VERSION")
+            ))
             .map_err(|err| miette::miette!(err))?;
         return Ok(());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use tracing_subscriber::util::SubscriberInitExt;
 extern crate core;
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None, name = "hj")]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -103,7 +103,7 @@ async fn main() -> miette::Result<()> {
     let exe_name = env_ref.exe_name();
     let rest_args = args[1..].to_vec();
 
-    if !exe_name.eq(env!("CARGO_PKG_NAME")) {
+    if !exe_name.eq(env!("CARGO_BIN_NAME")) {
         let root_dir = env_ref.root_dir();
         let dirs = adapters::dirs::Dirs::try_new(root_dir.as_deref(), env_ref)?;
         let paths = adapters::path::FsPaths::new(dirs.root_dir.clone());


### PR DESCRIPTION
build the bin as hj and make the proxy shim use the bin name for version probes and output. also updates clap display name and the readme examples so users type the command that actually exists.