### PR TITLE
hurl: add release probes for package downloads

### DIFF
--- a/hurl/aiken.hurl
+++ b/hurl/aiken.hurl
@@ -1,0 +1,3 @@
+GET https://github.com/aiken-lang/aiken/releases/download/v1.1.21/aiken-aarch64-apple-darwin.tar.gz
+User-Agent: Hyper-Jump
+HTTP 200

--- a/hurl/cardano-submit-api.hurl
+++ b/hurl/cardano-submit-api.hurl
@@ -1,0 +1,3 @@
+GET https://github.com/intersectmbo/cardano-node/releases/download/9.0.0/cardano-node-9.0.0-macos.tar.gz
+User-Agent: Hyper-Jump
+HTTP 200

--- a/hurl/dolos.hurl
+++ b/hurl/dolos.hurl
@@ -1,0 +1,3 @@
+GET https://github.com/txpipe/dolos/releases/download/v0.33.1/dolos-aarch64-apple-darwin.tar.gz
+User-Agent: Hyper-Jump
+HTTP 200

--- a/hurl/jujutsu.hurl
+++ b/hurl/jujutsu.hurl
@@ -1,0 +1,3 @@
+GET https://github.com/jj-vcs/jj/releases/download/v0.38.0/jj-v0.38.0-aarch64-apple-darwin.tar.gz
+User-Agent: Hyper-Jump
+HTTP 200

--- a/hurl/mithril.hurl
+++ b/hurl/mithril.hurl
@@ -1,3 +1,3 @@
-GET https://github.com//input-output-hk/mithril/releases/download/2423.0/mithril-2423.0-macos-arm64.tar.gz
+GET https://github.com/input-output-hk/mithril/releases/download/2543.1-hotfix/mithril-2543.1-hotfix-macos-arm64.tar.gz
 User-Agent: Hyper-Jump
 HTTP 200

--- a/hurl/neovim.hurl
+++ b/hurl/neovim.hurl
@@ -1,0 +1,3 @@
+GET https://github.com/neovim/neovim/releases/download/v0.11.6/nvim-macos-arm64.tar.gz
+User-Agent: Hyper-Jump
+HTTP 200

--- a/hurl/oura.hurl
+++ b/hurl/oura.hurl
@@ -1,0 +1,3 @@
+GET https://github.com/txpipe/oura/releases/latest/download/oura-aarch64-apple-darwin.tar.xz
+User-Agent: Hyper-Jump
+HTTP 200

--- a/hurl/partner-chains-cli.hurl
+++ b/hurl/partner-chains-cli.hurl
@@ -1,0 +1,3 @@
+GET https://github.com/input-output-hk/partner-chains/releases/download/v1.8.1/macos_arm64.zip
+User-Agent: Hyper-Jump
+HTTP 200

--- a/hurl/partner-chains-node.hurl
+++ b/hurl/partner-chains-node.hurl
@@ -1,0 +1,3 @@
+GET https://github.com/input-output-hk/partner-chains/releases/download/v1.8.1/macos_arm64.zip
+User-Agent: Hyper-Jump
+HTTP 200

--- a/hurl/reth.hurl
+++ b/hurl/reth.hurl
@@ -1,0 +1,3 @@
+GET https://github.com/paradigmxyz/reth/releases/download/v1.10.2/reth-v1.10.2-aarch64-apple-darwin.tar.gz
+User-Agent: Hyper-Jump
+HTTP 200

--- a/hurl/scrolls.hurl
+++ b/hurl/scrolls.hurl
@@ -1,0 +1,3 @@
+GET https://github.com/txpipe/scrolls/releases/download/v0.5.0/scrolls-aarch64-apple-darwin.tar.gz
+User-Agent: Hyper-Jump
+HTTP 200

--- a/hurl/sidechain-cli.hurl
+++ b/hurl/sidechain-cli.hurl
@@ -1,0 +1,3 @@
+GET https://github.com/input-output-hk/partner-chains/releases/download/v1.8.1/macos_arm64.zip
+User-Agent: Hyper-Jump
+HTTP 200

--- a/hurl/zellij.hurl
+++ b/hurl/zellij.hurl
@@ -1,0 +1,3 @@
+GET https://github.com/zellij-org/zellij/releases/download/v0.43.1/zellij-aarch64-apple-darwin.tar.gz
+User-Agent: Hyper-Jump
+HTTP 200


### PR DESCRIPTION
add hurl probes for package download urls so we can smoke check release assets and catch renames earlier.